### PR TITLE
feat: support merged commanders

### DIFF
--- a/packages/commands/examples/merge-commanders.ts
+++ b/packages/commands/examples/merge-commanders.ts
@@ -2,8 +2,8 @@ import { Module } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { Command, Commander, CommandModule, CommandService } from "../src";
 
-// ts-node ./examples/merge-commanders --help
-@Commander()
+// ts-node ./examples/merge-commanders merge --help
+@Commander({ name: "merge" })
 class TestCommander1 {
   @Command({ name: "test1" })
   public serve(): void {
@@ -11,7 +11,7 @@ class TestCommander1 {
   }
 }
 
-@Commander()
+@Commander({ name: "merge" })
 class TestCommander2 {
   @Command({ name: "test2" })
   public serve(): void {

--- a/packages/commands/examples/merge-commanders.ts
+++ b/packages/commands/examples/merge-commanders.ts
@@ -1,0 +1,31 @@
+import { Module } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { Command, Commander, CommandModule, CommandService } from "../src";
+
+// ts-node ./examples/merge-commanders --help
+@Commander()
+class TestCommander1 {
+  @Command({ name: "test1" })
+  public serve(): void {
+    console.log("Run test1 command");
+  }
+}
+
+@Commander()
+class TestCommander2 {
+  @Command({ name: "test2" })
+  public serve(): void {
+    console.log("Run test2 command");
+  }
+}
+
+@Module({
+  imports: [CommandModule.register()],
+  providers: [TestCommander1, TestCommander2],
+})
+class TestAppModule {}
+
+(async (): Promise<void> => {
+  const app = await NestFactory.createApplicationContext(TestAppModule, { logger: false });
+  app.get(CommandService).exec();
+})();

--- a/packages/commands/src/command.service.spec.ts
+++ b/packages/commands/src/command.service.spec.ts
@@ -180,5 +180,47 @@ describe("CommandService", () => {
       await parse(service, ["nested", "test"]);
       await expect(mock).toHaveBeenCalled();
     });
+
+    it("should merge commanders", async () => {
+      const service = new CommandService({ locale: "en_us", scriptName: "test" });
+      service.commanders.push({
+        commands: [
+          {
+            instance: jest.fn(),
+            name: "test",
+            options: [],
+            positionals: [],
+          },
+        ],
+        instance: jest.fn(),
+      } as CommanderInterface);
+      service.commanders.push({
+        commands: [
+          {
+            instance: jest.fn(),
+            name: "test2",
+            options: [],
+            positionals: [],
+          },
+        ],
+        instance: jest.fn(),
+      } as CommanderInterface);
+
+      /**
+       *  test <command>
+       *
+       *  Commands:
+       *    test test
+       *    test test2
+       *
+       *  Options:
+       *    --help     Show help                                                 [boolean]
+       *    --version  Show version number                                       [boolean]
+       */
+      const output = await parse(service, ["--help"]);
+
+      expect(output).toEqual(expect.stringContaining("test test"));
+      expect(output).toEqual(expect.stringContaining("test test2"));
+    });
   });
 });

--- a/packages/commands/src/explorer.service.spec.ts
+++ b/packages/commands/src/explorer.service.spec.ts
@@ -1,0 +1,339 @@
+import { MetadataScanner } from "@nestjs/core/metadata-scanner";
+import { Test } from "@nestjs/testing";
+import { Command, Commander, CommandOption, CommandPositional } from "./command.decorator";
+import { ExplorerService } from "./explorer.service";
+
+describe("ExplorerService", () => {
+  it("should be defined", () => {
+    expect(ExplorerService).toBeDefined();
+  });
+
+  describe("explore", () => {
+    it("should be defined", async () => {
+      const app = await Test.createTestingModule({
+        providers: [MetadataScanner, ExplorerService],
+      }).compile();
+
+      const service = app.get<ExplorerService>(ExplorerService);
+      expect(service.explore).toBeDefined();
+    });
+
+    describe("should run explore", () => {
+      it("no commander", async () => {
+        const app = await Test.createTestingModule({
+          providers: [MetadataScanner, ExplorerService],
+        }).compile();
+
+        const service = app.get<ExplorerService>(ExplorerService);
+        expect(service.explore()).toStrictEqual([]);
+      });
+
+      it("1 commander", async () => {
+        @Commander()
+        class TestCommander {
+          @Command({ name: "basic" })
+          public basic(): void {
+            console.log("hello!");
+          }
+        }
+        const app = await Test.createTestingModule({
+          providers: [MetadataScanner, ExplorerService, TestCommander],
+        }).compile();
+
+        const service = app.get<ExplorerService>(ExplorerService);
+        expect(service.explore()).toStrictEqual([
+          {
+            commands: [
+              {
+                instance: expect.any(Function),
+                name: "basic",
+                options: [],
+                positionals: [],
+              },
+            ],
+            instance: app.get<TestCommander>(TestCommander),
+          },
+        ]);
+      });
+
+      it("1 commander with 1 option", async () => {
+        @Commander()
+        class TestCommander {
+          @Command({ name: "basic" })
+          public basic(
+            @CommandOption({
+              alias: "v",
+              default: false,
+              description: "Run with verbose logging",
+              name: "verbose",
+              type: "boolean",
+            })
+            verbose: boolean,
+          ): void {
+            console.log({ verbose });
+          }
+        }
+        const app = await Test.createTestingModule({
+          providers: [MetadataScanner, ExplorerService, TestCommander],
+        }).compile();
+
+        const service = app.get<ExplorerService>(ExplorerService);
+        expect(service.explore()).toStrictEqual([
+          {
+            commands: [
+              {
+                instance: expect.any(Function),
+                name: "basic",
+                options: [
+                  {
+                    options: {
+                      alias: "v",
+                      default: false,
+                      description: "Run with verbose logging",
+                      name: "verbose",
+                      type: "boolean",
+                    },
+                    parameterIndex: 0,
+                  },
+                ],
+                positionals: [],
+              },
+            ],
+            instance: app.get<TestCommander>(TestCommander),
+          },
+        ]);
+      });
+
+      it("1 commander with 1 positional", async () => {
+        @Commander()
+        class TestCommander {
+          @Command({ name: "basic" })
+          public basic(
+            @CommandPositional({
+              default: 5000,
+              describe: "port to bind on",
+              name: "port",
+            })
+            port: number,
+          ): void {
+            console.log({ port });
+          }
+        }
+        const app = await Test.createTestingModule({
+          providers: [MetadataScanner, ExplorerService, TestCommander],
+        }).compile();
+
+        const service = app.get<ExplorerService>(ExplorerService);
+        expect(service.explore()).toStrictEqual([
+          {
+            commands: [
+              {
+                instance: expect.any(Function),
+                name: "basic",
+                options: [],
+                positionals: [
+                  {
+                    options: {
+                      default: 5000,
+                      describe: "port to bind on",
+                      name: "port",
+                    },
+                    parameterIndex: 0,
+                  },
+                ],
+              },
+            ],
+            instance: app.get<TestCommander>(TestCommander),
+          },
+        ]);
+      });
+
+      it("1 commander with 2 options and 2 positionals", async () => {
+        @Commander()
+        class TestCommander {
+          @Command({ name: "basic" })
+          public basic(
+            @CommandPositional({
+              default: 5000,
+              describe: "port to bind on",
+              name: "port1",
+            })
+            port1: number,
+            @CommandOption({
+              alias: "v1",
+              default: false,
+              description: "Run with verbose logging",
+              name: "verbose1",
+              type: "boolean",
+            })
+            verbose1: boolean,
+            @CommandPositional({
+              default: 5000,
+              describe: "port to bind on",
+              name: "port2",
+            })
+            port2: number,
+
+            @CommandOption({
+              alias: "v2",
+              default: false,
+              description: "Run with verbose logging",
+              name: "verbose2",
+              type: "boolean",
+            })
+            verbose2: boolean,
+          ): void {
+            console.log({ port1, port2, verbose1, verbose2 });
+          }
+        }
+        const app = await Test.createTestingModule({
+          providers: [MetadataScanner, ExplorerService, TestCommander],
+        }).compile();
+
+        const service = app.get<ExplorerService>(ExplorerService);
+        expect(service.explore()).toStrictEqual([
+          {
+            commands: [
+              {
+                instance: expect.any(Function),
+                name: "basic",
+                options: [
+                  {
+                    options: {
+                      alias: "v1",
+                      default: false,
+                      description: "Run with verbose logging",
+                      name: "verbose1",
+                      type: "boolean",
+                    },
+                    parameterIndex: 1,
+                  },
+                  {
+                    options: {
+                      alias: "v2",
+                      default: false,
+                      description: "Run with verbose logging",
+                      name: "verbose2",
+                      type: "boolean",
+                    },
+                    parameterIndex: 3,
+                  },
+                ],
+                positionals: [
+                  {
+                    options: {
+                      default: 5000,
+                      describe: "port to bind on",
+                      name: "port1",
+                    },
+                    parameterIndex: 0,
+                  },
+                  {
+                    options: {
+                      default: 5000,
+                      describe: "port to bind on",
+                      name: "port2",
+                    },
+                    parameterIndex: 2,
+                  },
+                ],
+              },
+            ],
+            instance: app.get<TestCommander>(TestCommander),
+          },
+        ]);
+      });
+
+      it("2 commanders", async () => {
+        @Commander({ name: "test1" })
+        class Test1Commander {
+          @Command({ name: "basic" })
+          public basic(): void {
+            console.log("hello!");
+          }
+        }
+
+        @Commander({ name: "test2" })
+        class Test2Commander {
+          @Command({ name: "basic" })
+          public basic(): void {
+            console.log("hello!");
+          }
+        }
+        const app = await Test.createTestingModule({
+          providers: [MetadataScanner, ExplorerService, Test1Commander, Test2Commander],
+        }).compile();
+
+        const service = app.get<ExplorerService>(ExplorerService);
+        expect(service.explore()).toStrictEqual([
+          {
+            commands: [
+              {
+                instance: expect.any(Function),
+                name: "basic",
+                options: [],
+                positionals: [],
+              },
+            ],
+            instance: app.get<Test1Commander>(Test1Commander),
+            name: "test1",
+          },
+          {
+            commands: [
+              {
+                instance: expect.any(Function),
+                name: "basic",
+                options: [],
+                positionals: [],
+              },
+            ],
+            instance: app.get<Test2Commander>(Test2Commander),
+            name: "test2",
+          },
+        ]);
+      });
+
+      it("merged 2 commanders", async () => {
+        @Commander()
+        class Test1Commander {
+          @Command({ name: "basic1" })
+          public basic(): void {
+            console.log("hello!");
+          }
+        }
+
+        @Commander()
+        class Test2Commander {
+          @Command({ name: "basic2" })
+          public basic(): void {
+            console.log("hello!");
+          }
+        }
+        const app = await Test.createTestingModule({
+          providers: [MetadataScanner, ExplorerService, Test1Commander, Test2Commander],
+        }).compile();
+
+        const service = app.get<ExplorerService>(ExplorerService);
+        expect(service.explore()).toStrictEqual([
+          {
+            commands: [
+              {
+                instance: expect.any(Function),
+                name: "basic1",
+                options: [],
+                positionals: [],
+              },
+              {
+                instance: expect.any(Function),
+                name: "basic2",
+                options: [],
+                positionals: [],
+              },
+            ],
+            instance: app.get<Test1Commander>(Test1Commander),
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/packages/commands/src/explorer.service.ts
+++ b/packages/commands/src/explorer.service.ts
@@ -29,11 +29,11 @@ export class ExplorerService {
       commander.commands = commands;
     }
 
-    return commanders.filter(commander => commander.commands.length !== 0);
+    return this.mergeCommanders(commanders).filter(commander => commander.commands.length !== 0);
   }
 
   private getCommanders(modules: Module[]): Commander[] {
-    const comamnders: Commander[] = [];
+    const commanders: Commander[] = [];
     const instanceWrappers = modules.map(module => [...module.providers.values()]).reduce((a, b) => a.concat(b), []);
 
     const classInstanceWrappers = instanceWrappers
@@ -47,11 +47,11 @@ export class ExplorerService {
       );
 
       if (metadata) {
-        comamnders.push({ instance: classInstanceWrapper.instance, ...metadata });
+        commanders.push({ instance: classInstanceWrapper.instance, ...metadata });
       }
     }
 
-    return comamnders;
+    return commanders;
   }
 
   private getCommands(commander: Commander): Command[] {
@@ -94,5 +94,19 @@ export class ExplorerService {
     }
 
     return [];
+  }
+
+  private mergeCommanders(commanders: Commander[]): Commander[] {
+    const mergedCommanders: Map<string, Commander> = new Map<string, Commander>();
+    for (const commander of commanders) {
+      const commanderName = commander.name ?? "";
+      if (mergedCommanders.has(commanderName)) {
+        mergedCommanders.get(commanderName)?.commands.push(...commander.commands);
+      } else {
+        mergedCommanders.set(commanderName, commander);
+      }
+    }
+
+    return Array.from(mergedCommanders.values());
   }
 }

--- a/packages/commands/src/explorer.service.ts
+++ b/packages/commands/src/explorer.service.ts
@@ -29,7 +29,7 @@ export class ExplorerService {
       commander.commands = commands;
     }
 
-    return this.mergeCommanders(commanders).filter(commander => commander.commands.length !== 0);
+    return this.mergeCommanders(commanders);
   }
 
   private getCommanders(modules: Module[]): Commander[] {
@@ -107,6 +107,6 @@ export class ExplorerService {
       }
     }
 
-    return Array.from(mergedCommanders.values());
+    return Array.from(mergedCommanders.values()).filter(commander => commander.commands.length !== 0);
   }
 }


### PR DESCRIPTION
Should be merged same name commanders.

```typescript
@Commander({ name: "merge" })
class TestCommander1 {
  @Command({ name: "test1" })
  public serve(): void {
    console.log("Run test1 command");
  }
}

@Commander({ name: "merge" })
class TestCommander2 {
  @Command({ name: "test2" })
  public serve(): void {
    console.log("Run test2 command");
  }
}

@Module({
  imports: [CommandModule.register()],
  providers: [TestCommander1, TestCommander2],
})
class TestAppModule {}
```

```sh
ts-node ./examples/merge-commanders merge --help
```

output

```
merge-commanders merge

Commands:
  merge-commanders merge test1
  merge-commanders merge test2

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]
```